### PR TITLE
Add Prefix Tuning to BLOOM

### DIFF
--- a/src/transformers/adapters/prefix_tuning.py
+++ b/src/transformers/adapters/prefix_tuning.py
@@ -168,7 +168,7 @@ class PrefixTuningPool(nn.Module):
         for location_key, count in self.prefix_counts[prefix_name].items():
             module_configs[location_key] = {
                 "n_layers": count,
-                "n_heads": self.config.num_attention_heads,
+                "n_heads": self.config.num_attention_heads if not self.config.model_type == "bloom" else self.config.n_head,
                 "input_size": self.config.hidden_size,
             }
         prefix_tuning = PrefixTuningGroup(module_configs, prefix_tuning_config)

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -350,7 +350,14 @@ class BloomAttention(nn.Module):
             self.layer_number,
         )
 
-        self.query_key_value = nn.Linear(self.hidden_size, 3 * self.hidden_size, bias=True)
+        self.query_key_value = LoRAMergedLinear(
+                self.hidden_dim,
+                3 * self.embed_dim,
+                "selfattn",
+                config,
+                enable_lora=[True, False, True],
+                fan_in_fan_out=True,
+            )
         self.dense = nn.Linear(self.hidden_size, self.hidden_size)
         self.attention_dropout = nn.Dropout(config.attention_dropout)
 
@@ -484,8 +491,8 @@ class BloomMLP(nn.Module):
 
         self.pretraining_tp = config.pretraining_tp
         self.slow_but_exact = config.slow_but_exact
-        self.dense_h_to_4h = nn.Linear(hidden_size, 4 * hidden_size)
-        self.dense_4h_to_h = nn.Linear(4 * hidden_size, hidden_size)
+        self.c_fc = LoRALinear(hidden_size, 4 * hidden_size, "intermediate", config, fan_in_fan_out=True)
+        self.c_proj = LoRALinear(4 * hidden_size, hidden_size, "output", config, fan_in_fan_out=True)
         self.hidden_dropout = config.hidden_dropout
         self.gelu_impl = BloomGelu()
 


### PR DESCRIPTION
This PR adds prefix tuning to BLOOM.

let me know if you cannot follow what I've changed, but I've confirmed that when not enabling prefix tuning, this implementation gets the same initial loss exactly on the first logging steps.


There is no longer the slowdown issue that I mentioned on Slack!!!!
(Turns out just creating the alibi tensor using hidden states and only keeping the preprocessing of alibi to happen after the prefix tuning did the trick)

I am testing the loss curves now.